### PR TITLE
Add rename button

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 4
+
+[package.json]
+indent_size = 4

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
                 },
                 {
                     "command": "editor.action.rename",
-                    "group": "nasc"
+                    "group": "nasc",
+                    "when": "config.nasc-touchbar.rename"
                 },
                 {
                     "command": "workbench.action.togglePanel",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
                 "command": "workbench.action.showCommands",
                 "group": "nasc",
                 "title": ">_"
+            },
+            {
+                "command": "editor.action.rename",
+                "group": "nasc",
+                "title": "✎_"
             }
         ],
         "menus": {
@@ -80,6 +85,10 @@
                 },
                 {
                     "command": "workbench.action.toggleSidebarVisibility",
+                    "group": "nasc"
+                },
+                {
+                    "command": "editor.action.rename",
                     "group": "nasc"
                 },
                 {


### PR DESCRIPTION
**This is not ready to merge**

Adding the extra button makes the app controls too wide if you have the control strip enabled, making it disappear entirely. 

I'd suggest that the "add cursor above" and below buttons could be removed since they already have keybindings without the F keys.