### PR TITLE
Fixing some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The list of features are:
 
 - Go to definition
 - Add cursor above
-- Add cursor bellow
+- Add cursor below
 - Run command
 - Toggle side bar
 - Toggle Pannel/terminal
@@ -25,7 +25,7 @@ Please have in mind the limit of 6 active buttons (if you have the OS controll s
 
 - "nasc-touchbar.goToDefinition": (default _true_) Go to the function or variable definition
 - "nasc-touchbar.addCursorAbove": (default _false_) Add a cursor in the line above
-- "nasc-touchbar.addCursorBellow": (default _true_) Add a cursor in the line bellow
+- "nasc-touchbar.addCursorBelow": (default _true_) Add a cursor in the line below
 - "nasc-touchbar.toggleSidebar": (default _false_) Toggles the sidebar
 - "nasc-touchbar.togglePanel": (default _true_) Toggles the panel in the bottom of the editor
 - "nasc-touchbar.showCommands": (default _true_) Shows the _run command_ prompt

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Please have in mind the limit of 6 active buttons (if you have the OS control st
 - "nasc-touchbar.togglePanel": (default _true_) Toggles the panel in the bottom of the editor
 - "nasc-touchbar.showCommands": (default _true_) Shows the _run command_ prompt
 - "nasc-touchbar.rename": (default _true_) Rename (replace all) variable or function names
-<<<<<<< HEAD
-=======
 - "nasc-touchbar.copyLineDown": (default _false_) Duplicates the current line (or selected lines) 
 - "nasc-touchbar.goToNext": (default _false_) Go to next match
 - "nasc-touchbar.toggleWhiteSpace": (default _false_) Show or hide white spaces
@@ -62,4 +60,3 @@ Important, if the buttons don't fit in the bar, they will not be shown (this is 
 If the bar disappeared, see the options (ctrl+, or cmd+,), filter by "nasc" e adjust the settings.
 
 Usually, if your are not using the "Strip" group of buttons, you can fit **9** buttons on it. If you have the OS's _Strip_ buttons enabled, you can fit **6** buttons.
->>>>>>> NascHQ/master

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The list of features are:
 - Add cursor below
 - Run command
 - Toggle side bar
-- Toggle Pannel/terminal
+- Toggle Panel/terminal
 - Rename/replace all
 
 ## Settings
 
 You can choose the buttons by setting the following settings.  
-Please have in mind the limit of 6 active buttons (if you have the OS controll strip enabled, 9 buttons if you don't) . More than that will break the layout and the buttons will not be visible.
+Please have in mind the limit of 6 active buttons (if you have the OS control strip enabled, 9 buttons if you don't) . More than that will break the layout and the buttons will not be visible.
 
 - "nasc-touchbar.goToDefinition": (default _true_) Go to the function or variable definition
 - "nasc-touchbar.addCursorAbove": (default _false_) Add a cursor in the line above

--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,7 @@ function addCursor (direction) {
     var position = editor.selection.active;
     var selections = editor.selections
     var selection
-    
+
     if (selections.length > 1) {
         selections = selections.sort((a, b) => {
             return a.start.line > b.start.line
@@ -55,7 +55,7 @@ function addCursor (direction) {
         let tabs = countTabs(selection)
         let tabs2 = countTabs(newSelection)
         let diff = (tabs - tabs2)
-        
+
         if (Math.abs(diff) > 0) {
             diff = diff * editor.options.tabSize - diff
         }
@@ -72,8 +72,8 @@ function activate(context) {
     const aCA = vscode.commands.registerCommand('nasc.touchBar.addCursorAbove', function () {
         addCursor('above')
     })
-    const aCB = vscode.commands.registerCommand('nasc.touchBar.addCursorBellow', function () {
-        addCursor('bellow')
+    const aCB = vscode.commands.registerCommand('nasc.touchBar.addCursorBelow', function () {
+        addCursor('below')
     })
 
     vscode.commands.registerCommand('nasc.touchBar.goToDefinition', function () {
@@ -82,10 +82,10 @@ function activate(context) {
         if (!editor) {
             return; // No open text editor
         }
-        
+
         var position = editor.selection.active;
 
-        vscode.commands.executeCommand('vscode.executeDefinitionProvider', 
+        vscode.commands.executeCommand('vscode.executeDefinitionProvider',
             editor.document.uri,
             position
         ).then(result => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "activationEvents": [
         "onCommand:nasc.touchBar.goToDefinition",
         "onCommand:nasc.touchBar.addCursorAbove",
-        "onCommand:nasc.touchBar.addCursorBellow"
+        "onCommand:nasc.touchBar.addCursorBelow"
     ],
     "main": "./extension",
     "capabilities": {
@@ -44,7 +44,7 @@
                 "title": "↑𝙸"
             },
             {
-                "command": "nasc.touchBar.addCursorBellow",
+                "command": "nasc.touchBar.addCursorBelow",
                 "group": "nasc",
                 "title": "↓𝙸"
             },
@@ -82,9 +82,9 @@
                     "when": "config.nasc-touchbar.addCursorAbove"
                 },
                 {
-                    "command": "nasc.touchBar.addCursorBellow",
+                    "command": "nasc.touchBar.addCursorBelow",
                     "group": "nasc",
-                    "when": "config.nasc-touchbar.addCursorBellow"
+                    "when": "config.nasc-touchbar.addCursorBelow"
                 },
                 {
                     "command": "workbench.action.toggleSidebarVisibility",
@@ -123,10 +123,10 @@
                         "default": false,
                         "description": "Add cursor above"
                     },
-                    "nasc-touchbar.addCursorBellow": {
+                    "nasc-touchbar.addCursorBelow": {
                         "type": "boolean",
                         "default": true,
-                        "description": "Add cursor bellow"
+                        "description": "Add cursor below"
                     },
                     "nasc-touchbar.toggleSidebar": {
                         "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nasc-touchbar",
     "displayName": "Nasc VSCode Touchbar",
-    "description": "Adds useful tools to your macbook touchbar.",
+    "description": "Adds useful tools to your Macbook touchbar.",
     "version": "1.5.0",
     "publisher": "felipe",
     "engines": {
@@ -110,7 +110,7 @@
         },
         "configuration": [
             {
-                "title": "Something",
+                "title": "Nasc Touch Bar Settings",
                 "type": "object",
                 "properties": {
                     "nasc-touchbar.goToDefinition": {


### PR DESCRIPTION
There’s a few typos in the README, and “below” is misspelled in the settings.