### PR TITLE
Fixed cursor below not working due to typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
                 {
                     "command": "nasc.touchBar.addCursorBelow",
                     "group": "nasc",
-                    "when": "config.nasc-touchbar.addCursorBellow && !enabledGroup"
+                    "when": "config.nasc-touchbar.addCursorBelow && !enabledGroup"
                 },
                 {
                     "command": "nasc.touchBar.addCursorBelow",


### PR DESCRIPTION
Title is pretty self-explanatory, there was a typo that caused the `addCursorBelow` option to ignore settings and never show