### PR TITLE
Add support for dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Please have in mind the limit of 6 active buttons (if you have the OS control st
 - "nasc-touchbar.jumpToBracket": (default _false_) Jump to matching bracket
 - "nasc-touchbar.blockComment": (default _false_) Toggles block comments ( /* ... */ ) for the current selection
 - "nasc-touchbar.commentLine": (default _false_) Toggles line comments ( // ) for the current selection
+- "nasc-touchbar.docs": (default _false_) Show documentation for current file in Dash / Zeal. Requires extension _deerawan.vscode-dash_
 - "nasc-touchbar.enableFuncGroup": (default _false_) Adds a group with the buttons related to _Functions_
 - "nasc-touchbar.enableSrcGroup": (default _false_)  Adds a group with the buttons related to the _Source code_
 - "nasc-touchbar.enableCursorsGroup": (default _false_)  Adds a group with the buttons related to your _cursors_

--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
                 "command": "git.sync",
                 "group": "nasc",
                 "title": "↻"
+            },
+            {
+                "command": "extension.dash.emptySyntax",
+                "group": "nasc",
+                "title": "🧠"
             }
         ],
         "menus": {
@@ -385,6 +390,11 @@
                     "command": "git.sync",
                     "group": "nasc",
                     "when": "config.nasc-touchbar.gitSync && !enabledGroup"
+                },
+                {
+                    "command": "extension.dash.emptySyntax",
+                    "group": "nasc",
+                    "when": "config.nasc-touchbar.docs && !enabledGroup"
                 }
             ]
         },
@@ -512,6 +522,11 @@
                         "type": "boolean",
                         "default": false,
                         "description": "Git Sync"
+                    },
+                    "nasc-touchbar.docs": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Documentation"
                     }
                 }
             }


### PR DESCRIPTION
[Dash](https://kapeli.com/dash) is a great utility for showing a modal with documentation for many languages and frameworks.

I've used an emoji for the icon as i find it quicker to distinguish colours on the touch bar than simple white icons. I'm happy to change it to a simple unicode symbol if that is a problem.

This addition requires [a vscode dash extension](https://marketplace.visualstudio.com/items?itemName=deerawan.vscode-dash) to work correctly